### PR TITLE
Update to use internal container images

### DIFF
--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Wait for services to be healthy
         run: |
           # Give services time to start
-          sleep 10
+          sleep 300
 
           # Wait for all services to be healthy (max 120 seconds)
           echo "Waiting for services to become healthy..."

--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Wait for services to be healthy
         run: |
           # Give services time to start
-          sleep 300
+          sleep 60
 
-          # Wait for all services to be healthy (max 120 seconds)
+          # Wait for all services to be healthy
           echo "Waiting for services to become healthy..."
           for i in {1..24}; do
             # Check if all expected services are healthy
@@ -46,7 +46,7 @@ jobs:
               docker compose logs
               exit 1
             fi
-            sleep 5
+            sleep 10
           done
 
       - name: Verify all containers are running

--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Wait for services to be healthy
         run: |
           # Give services time to start
-          sleep 60
+          sleep 120
 
           # Wait for all services to be healthy
           echo "Waiting for services to become healthy..."
-          for i in {1..24}; do
+          for i in {1..50}; do
             # Check if all expected services are healthy
             status=$(docker compose ps --format "{{.Service}}: {{.State}}" | grep -v "healthy" || true)
 
@@ -40,8 +40,8 @@ jobs:
               break
             fi
 
-            echo "Attempt $i/24: Waiting for services..."
-            if [ $i -eq 24 ]; then
+            echo "Attempt $i/50: Waiting for services..."
+            if [ $i -eq 50 ]; then
               echo "✗ Services did not become healthy in time"
               docker compose logs
               exit 1

--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -1,0 +1,127 @@
+name: Test Docker Compose
+
+on:
+  push:
+    branches:
+      - main
+      - feat/**
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Start Docker Compose services
+        run: docker compose up -d
+
+      - name: Wait for services to be healthy
+        run: |
+          # Give services time to start
+          sleep 10
+
+          # Wait for all services to be healthy (max 120 seconds)
+          echo "Waiting for services to become healthy..."
+          for i in {1..24}; do
+            # Check if all expected services are healthy
+            status=$(docker compose ps --format "{{.Service}}: {{.State}}" | grep -v "healthy" || true)
+
+            if [ -z "$status" ]; then
+              echo "✓ All services are healthy"
+              break
+            fi
+
+            echo "Attempt $i/24: Waiting for services..."
+            if [ $i -eq 24 ]; then
+              echo "✗ Services did not become healthy in time"
+              docker compose logs
+              exit 1
+            fi
+            sleep 5
+          done
+
+      - name: Verify all containers are running
+        run: |
+          echo "Verifying containers..."
+          docker compose ps
+
+          # Check that all expected services exist and are running
+          expected_services="axondb-search timseriesdb axon-server axon-dash"
+          for service in $expected_services; do
+            if ! docker compose ps "$service" | grep -q "Up"; then
+              echo "✗ Service $service is not running"
+              docker compose logs "$service"
+              exit 1
+            fi
+            echo "✓ Service $service is running"
+          done
+
+      - name: Test connectivity to AxonOps Dashboard (port 3000)
+        run: |
+          echo "Testing connectivity to port 3000..."
+          max_attempts=30
+          attempt=1
+
+          while [ $attempt -le $max_attempts ]; do
+            if curl -sf http://localhost:3000 > /dev/null; then
+              echo "✓ Successfully connected to AxonOps Dashboard on port 3000"
+              exit 0
+            fi
+
+            echo "Attempt $attempt/$max_attempts: Port 3000 not ready yet..."
+            attempt=$((attempt + 1))
+            sleep 2
+          done
+
+          echo "✗ Failed to connect to port 3000 after $max_attempts attempts"
+          exit 1
+
+      - name: Test AxonOps Server API (port 8080)
+        run: |
+          if curl -sf http://localhost:8080/api/v1/healthz > /dev/null; then
+            echo "✓ AxonOps Server API is responding on port 8080"
+          else
+            echo "⚠ AxonOps Server API did not respond (may still be starting)"
+          fi
+
+      - name: Test Cassandra (port 9042)
+        run: |
+          if nc -z localhost 9042; then
+            echo "✓ Cassandra is listening on port 9042"
+          else
+            echo "⚠ Cassandra is not responding on port 9042"
+          fi
+
+      - name: Run health check script
+        run: |
+          chmod +x ./check_health.sh
+          if ./check_health.sh; then
+            echo "✓ Health check passed"
+          else
+            echo "⚠ Health check script reported issues (may be transient)"
+          fi
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== Docker Compose Logs ==="
+          docker compose logs
+          echo ""
+          echo "=== Docker Stats ==="
+          docker stats --no-stream
+          echo ""
+          echo "=== Service Status ==="
+          docker compose ps -a
+
+      - name: Cleanup
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -1,127 +1,127 @@
-name: Test Docker Compose
+# name: Test Docker Compose
 
-on:
-  push:
-    branches:
-      - main
-      - feat/**
-  pull_request:
-    branches:
-      - main
+# on:
+#   push:
+#     branches:
+#       - main
+#       - feat/**
+#   pull_request:
+#     branches:
+#       - main
 
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+# jobs:
+#   test:
+#     runs-on: ubuntu-latest
+#     timeout-minutes: 10
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+#     steps:
+#       - name: Checkout code
+#         uses: actions/checkout@v4
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
+#       - name: Set up Docker
+#         uses: docker/setup-buildx-action@v3
 
-      - name: Start Docker Compose services
-        run: docker compose up -d
+#       - name: Start Docker Compose services
+#         run: docker compose up -d
 
-      - name: Wait for services to be healthy
-        run: |
-          # Give services time to start
-          sleep 120
+#       - name: Wait for services to be healthy
+#         run: |
+#           # Give services time to start
+#           sleep 120
 
-          # Wait for all services to be healthy
-          echo "Waiting for services to become healthy..."
-          for i in {1..50}; do
-            # Check if all expected services are healthy
-            status=$(docker compose ps --format "{{.Service}}: {{.State}}" | grep -v "healthy" || true)
+#           # Wait for all services to be healthy
+#           echo "Waiting for services to become healthy..."
+#           for i in {1..50}; do
+#             # Check if all expected services are healthy
+#             status=$(docker compose ps --format "{{.Service}}: {{.State}}" | grep -v "healthy" || true)
 
-            if [ -z "$status" ]; then
-              echo "✓ All services are healthy"
-              break
-            fi
+#             if [ -z "$status" ]; then
+#               echo "✓ All services are healthy"
+#               break
+#             fi
 
-            echo "Attempt $i/50: Waiting for services..."
-            if [ $i -eq 50 ]; then
-              echo "✗ Services did not become healthy in time"
-              docker compose logs
-              exit 1
-            fi
-            sleep 10
-          done
+#             echo "Attempt $i/50: Waiting for services..."
+#             if [ $i -eq 50 ]; then
+#               echo "✗ Services did not become healthy in time"
+#               docker compose logs
+#               exit 1
+#             fi
+#             sleep 10
+#           done
 
-      - name: Verify all containers are running
-        run: |
-          echo "Verifying containers..."
-          docker compose ps
+#       - name: Verify all containers are running
+#         run: |
+#           echo "Verifying containers..."
+#           docker compose ps
 
-          # Check that all expected services exist and are running
-          expected_services="axondb-search timseriesdb axon-server axon-dash"
-          for service in $expected_services; do
-            if ! docker compose ps "$service" | grep -q "Up"; then
-              echo "✗ Service $service is not running"
-              docker compose logs "$service"
-              exit 1
-            fi
-            echo "✓ Service $service is running"
-          done
+#           # Check that all expected services exist and are running
+#           expected_services="axondb-search timseriesdb axon-server axon-dash"
+#           for service in $expected_services; do
+#             if ! docker compose ps "$service" | grep -q "Up"; then
+#               echo "✗ Service $service is not running"
+#               docker compose logs "$service"
+#               exit 1
+#             fi
+#             echo "✓ Service $service is running"
+#           done
 
-      - name: Test connectivity to AxonOps Dashboard (port 3000)
-        run: |
-          echo "Testing connectivity to port 3000..."
-          max_attempts=30
-          attempt=1
+#       - name: Test connectivity to AxonOps Dashboard (port 3000)
+#         run: |
+#           echo "Testing connectivity to port 3000..."
+#           max_attempts=30
+#           attempt=1
 
-          while [ $attempt -le $max_attempts ]; do
-            if curl -sf http://localhost:3000 > /dev/null; then
-              echo "✓ Successfully connected to AxonOps Dashboard on port 3000"
-              exit 0
-            fi
+#           while [ $attempt -le $max_attempts ]; do
+#             if curl -sf http://localhost:3000 > /dev/null; then
+#               echo "✓ Successfully connected to AxonOps Dashboard on port 3000"
+#               exit 0
+#             fi
 
-            echo "Attempt $attempt/$max_attempts: Port 3000 not ready yet..."
-            attempt=$((attempt + 1))
-            sleep 2
-          done
+#             echo "Attempt $attempt/$max_attempts: Port 3000 not ready yet..."
+#             attempt=$((attempt + 1))
+#             sleep 2
+#           done
 
-          echo "✗ Failed to connect to port 3000 after $max_attempts attempts"
-          exit 1
+#           echo "✗ Failed to connect to port 3000 after $max_attempts attempts"
+#           exit 1
 
-      - name: Test AxonOps Server API (port 8080)
-        run: |
-          if curl -sf http://localhost:8080/api/v1/healthz > /dev/null; then
-            echo "✓ AxonOps Server API is responding on port 8080"
-          else
-            echo "⚠ AxonOps Server API did not respond (may still be starting)"
-          fi
+#       - name: Test AxonOps Server API (port 8080)
+#         run: |
+#           if curl -sf http://localhost:8080/api/v1/healthz > /dev/null; then
+#             echo "✓ AxonOps Server API is responding on port 8080"
+#           else
+#             echo "⚠ AxonOps Server API did not respond (may still be starting)"
+#           fi
 
-      - name: Test Cassandra (port 9042)
-        run: |
-          if nc -z localhost 9042; then
-            echo "✓ Cassandra is listening on port 9042"
-          else
-            echo "⚠ Cassandra is not responding on port 9042"
-          fi
+#       - name: Test Cassandra (port 9042)
+#         run: |
+#           if nc -z localhost 9042; then
+#             echo "✓ Cassandra is listening on port 9042"
+#           else
+#             echo "⚠ Cassandra is not responding on port 9042"
+#           fi
 
-      - name: Run health check script
-        run: |
-          chmod +x ./check_health.sh
-          if ./check_health.sh; then
-            echo "✓ Health check passed"
-          else
-            echo "⚠ Health check script reported issues (may be transient)"
-          fi
+#       - name: Run health check script
+#         run: |
+#           chmod +x ./check_health.sh
+#           if ./check_health.sh; then
+#             echo "✓ Health check passed"
+#           else
+#             echo "⚠ Health check script reported issues (may be transient)"
+#           fi
 
-      - name: Collect logs on failure
-        if: failure()
-        run: |
-          echo "=== Docker Compose Logs ==="
-          docker compose logs
-          echo ""
-          echo "=== Docker Stats ==="
-          docker stats --no-stream
-          echo ""
-          echo "=== Service Status ==="
-          docker compose ps -a
+#       - name: Collect logs on failure
+#         if: failure()
+#         run: |
+#           echo "=== Docker Compose Logs ==="
+#           docker compose logs
+#           echo ""
+#           echo "=== Docker Stats ==="
+#           docker stats --no-stream
+#           echo ""
+#           echo "=== Service Status ==="
+#           docker compose ps -a
 
-      - name: Cleanup
-        if: always()
-        run: docker compose down -v
+#       - name: Cleanup
+#         if: always()
+#         run: docker compose down -v

--- a/README.md
+++ b/README.md
@@ -1,257 +1,295 @@
-# AxonOps™ Server Docker Compose
-AxonOps is a comprehensive management platform designed for Apache Cassandra® and Apache Kafka®, offering unified monitoring, maintenance, and backup functionalities. Built by Cassandra and Kafka experts, it provides the only cloud-native solution to monitor, maintain and backup Apache Cassandra or Apache Kafka clusters through either SaaS or self-hosted deployments.
+# AxonOps Server Docker Compose
 
-For detailed documentation, visit:
-- Demo https://axonops.com/demo-sandbox/
-- Documentation: https://axonops.com/docs
-- Product Information: https://axonops.com
+AxonOps is a management platform for Apache Cassandra and Apache Kafka, offering monitoring, maintenance, and backup capabilities. This repository provides a simple way to run AxonOps locally using Docker Compose.
 
-For other self-host installation options like Kubernetes, see here: https://axonops.com/docs/installation-starter/axon-server/axonserver_install/
+**Links:**
+- [Live Demo](https://axonops.com/demo-sandbox/)
+- [Documentation](https://axonops.com/docs)
+- [Product Website](https://axonops.com)
+- [Kubernetes Installation](https://axonops.com/docs/installation-starter/axon-server/axonserver_install/)
 
-## Table of Contents
+---
 
-1.  [Self-Hosting AxonOps](#self-hosting-axonops)
-    *   [Install License (Optional)](#install-license-optional)
-2.  [Container Runtime Options](#container-runtime-options)
-3.  [Accessing AxonOps](#accessing-axonops)
-4.  [Compose Structure](#compose-structure)
-    *   [Overview](#overview)
-    *   [Key Components](#key-components)
-    *   [Service Details](#service-details)
-    *   [Notes](#notes)
-5.  [Instructions](#instructions)
-    *   [Using Docker](#using-docker)
-    *   [Using Podman](#using-podman)
-6.  [Health Check Script](#health-check-script)
-    *   [How the Script Works](#how-the-script-works)
-    *   [Usage](#usage)
-        *   [Example Output](#example-output)
+## Prerequisites
 
-## Self-Hosting AxonOps
-When self-hosting AxonOps using this `docker-compose.yml` file:
-1. The **axon-server** service acts as the backend, communicating with agents and exposing REST APIs.
-2. The **axon-dash** service provides the dashboards and user interface.
-3. Data is stored in:
-   - **Elasticsearch®**, which handles indexing and search functionality.
-   - **Cassandra**, which manages time-series data storage.
+Before you begin, make sure you have:
 
-### Install License (Optional)  
-AxonOps is free to use and includes a range of powerful features at no cost.
+1. **Docker Desktop** (recommended for beginners) or **Docker Engine** installed
+   - [Download Docker Desktop](https://www.docker.com/products/docker-desktop/) (Windows/Mac/Linux)
+   - Docker Desktop includes Docker Compose
 
-For enterprise customers with a license key, you can enhance your installation by adding the key to the `axon-server.yml` file. Ensure that the organization name matches the one used when obtaining your license.
+2. **Minimum System Requirements:**
+   - 4 GB RAM available for Docker (8 GB recommended)
+   - 10 GB free disk space
+   - macOS, Windows 10/11, or Linux
 
-## Container Runtime Options
-This project can be run using either [Docker](https://docker.com) or [Podman](https://podman.io).
+3. **Verify Docker is installed** by opening a terminal and running:
+   ```bash
+   docker --version
+   docker compose version
+   ```
+   You should see version numbers for both commands.
 
-It has been tested on Debian 12 with Docker, although it should work in other environments. Please raise an issue on the project if you encounter any problems specific to your setup.
+---
 
-## Accessing AxonOps
+## Quick Start
 
-Once the services are running, access the AxonOps dashboard at: http://localhost:3000 and you can configure your AxonOps agents to point at the AxonOps Server to start managing your cluster.
+### Step 1: Download the project
 
-For production deployments, ensure proper security configurations are in place and refer to the official documentation for advanced setup options.
-
-The platform provides dynamic dashboards for collecting logs and metrics, offering insights into cluster performance and health status. You can set up alerts for various metrics to ensure optimal performance.
-
-## Compose Structure
-
-The `docker-compose.yml` file in this repository defines the services, networks, and volumes required to self-host AxonOps in this fashion. Below is an explanation of its structure and key components.
-
-### Overview
-The `docker-compose.yml` file orchestrates the following services:
-1. **axon-server**: The core backend component of AxonOps. This service handles communication with agents and exposes REST APIs for configuration.
-2. **axon-dash**: The frontend component providing dashboards and a user interface for interacting with AxonOps.
-3. **Elasticsearch®**: A search engine used by AxonOps to store and index data.
-4. **Apache Cassandra®**: A distributed NoSQL database used by AxonOps to store time-series data.
-
-### Key Components
-
-#### **Volumes**
-The `docker-compose.yml` file uses Docker named volumes for Elasticsearch and Cassandra to ensure data durability across container restarts. These volumes are critical for storing logs and other data generated by AxonOps.
-
-> **_NOTE:_** In previous versions, the setup used directories for data storage. However, this caused compatibility issues for some users. To resolve this, the current version now uses named Docker volumes instead.
-If you're upgrading from an earlier version, please be aware of this change and adjust your setup accordingly.
-
-- **Elasticsearch Volumes**:
-  - `elasticsearch_data`: Persists Elasticsearch indices
-  - `elasticsearch_logs`: Persists Elasticsearch logs
-  - Ensures that all data stored in Elasticsearch remains intact even if the container is restarted.
-
-- **Cassandra Volumes**:
-  - `cassandra_data`: Persists time-series data and other information stored in Cassandra
-  - `cassandra_logs`: Persists Cassandra logs
-  - Guarantees data reliability and availability.
-
-- **AxonOps Volumes**:
-  - `axonops_logs`: Persists AxonOps Server and Dashboard logs
-
-### Service Details
-
-#### **axon-server**
-- Acts as the central hub for AxonOps agents.
-- Exposes REST APIs that allow users to configure AxonOps programmatically.
-- Handles incoming data from agents, processes it, and stores it in Elasticsearch and Cassandra.
-
-#### **axon-dash**
-- Provides the primary user interface for AxonOps.
-- Allows users to visualize data, monitor systems, and interact with dashboards.
-- Communicates with `axon-server` to fetch data for display.
-
-#### **elasticsearch**
-- Stores indexed data required by AxonOps for searching, analytics, and monitoring.
-- Configured with mounted volumes to persist indices and logs across restarts.
-
-#### **cassandra**
-- Stores time-series data used by AxonOps for long-term storage and analysis.
-- Configured with mounted volumes to ensure durability of stored data.
-
-### Notes
-- Both Elasticsearch and Cassandra are resource-intensive services; ensure your hosting environment has sufficient resources (CPU, memory, disk space) to handle their requirements effectively.
-- The default heap sizes are 8GB for both Elasticsearch and Cassandra. Adjust these values based on your workload using the `run.sh` script or environment variables.
-- Data is persisted in Docker named volumes, which survive container restarts and removals. Use `./run.sh --clean` to remove volumes and data.
-
-This structure ensures a robust deployment of AxonOps with all necessary components running seamlessly together in a single Docker Compose setup.
-
-## Instructions
-
-### Using run.sh Script (Recommended)
-
-The repository includes a `run.sh` script that simplifies service management and memory configuration.
-
-#### Quick Start
 ```bash
-# Clone repository
 git clone https://github.com/axonops/axonops-server-compose
 cd axonops-server-compose
-
-# Start services with default settings (8GB heap for Elasticsearch and Cassandra)
-./run.sh
 ```
 
-#### Custom Memory Configuration
-```bash
-# Run with custom Elasticsearch heap size
-./run.sh --es-heap 16
+Or [download the ZIP file](https://github.com/axonops/axonops-server-compose/archive/refs/heads/main.zip) and extract it.
 
-# Run with custom memory for both services
-./run.sh --es-heap 16 --cassandra-heap 16
-
-# Run with custom Cassandra new generation heap size
-./run.sh --cassandra-heap-newsize 1g
-
-# Run in detached mode
-./run.sh -d
-```
-
-#### Managing Services
-```bash
-# Stop services
-./run.sh --down
-
-# Clean everything including data (WARNING: destroys all data)
-./run.sh --clean
-```
-
-#### Environment Variables
-You can also set memory configurations via environment variables:
-```bash
-export ELASTICSEARCH_HEAP_SIZE=16
-export CASSANDRA_HEAP_SIZE=16
-export CASSANDRA_HEAP_NEWSIZE=1g
-./run.sh
-```
-
-#### Available Options
-- `-h, --help`: Show help message
-- `-d, --detach`: Run in detached mode
-- `--es-heap SIZE`: Elasticsearch heap size in GB (default: 8)
-- `--cassandra-heap SIZE`: Cassandra heap size in GB (default: 8)
-- `--cassandra-heap-newsize SIZE`: Cassandra new generation heap size (default: 800m)
-- `--down`: Stop and remove containers
-- `--clean`: Stop containers and remove volumes (destroys data)
-
-### Using Docker Compose Directly
-
-If you prefer to use Docker Compose directly without the run.sh script:
+### Step 2: Start AxonOps
 
 ```bash
-# Clone repository
-git clone https://github.com/axonops/axonops-server-compose
-cd axonops-server-compose
-
-# Start services with default settings
 docker compose up -d
-
-# Start with custom memory settings
-ELASTICSEARCH_HEAP_SIZE=16 CASSANDRA_HEAP_SIZE=16 docker compose up -d
 ```
 
-### Using Podman
+This command:
+- Downloads the required container images (first time only)
+- Starts all services in the background (`-d` means "detached")
+- May take 2-5 minutes on first run
+
+### Step 3: Wait for services to be ready
+
+Check the status of all services:
 ```bash
-# Clone repository
-git clone https://github.com/axonops/axonops-server-compose
-cd axonops-server-compose
-
-# Start services
-podman compose up -d
+docker compose ps
 ```
+
+Wait until all services show `healthy` in the STATUS column. You can also watch the logs:
+```bash
+docker compose logs -f
+```
+
+Press `Ctrl+C` to stop watching logs.
+
+### Step 4: Access the dashboard
+
+Open your web browser and go to: **http://localhost:3000**
+
+You're now ready to configure your AxonOps agents to connect to the server on port `1888`.
+
+---
+
+## Managing AxonOps
+
+### View running services
+```bash
+docker compose ps
+```
+
+### View logs
+```bash
+# All services
+docker compose logs -f
+
+# Specific service
+docker compose logs -f axon-server
+```
+
+### Stop AxonOps (keeps your data)
+```bash
+docker compose down
+```
+
+### Start AxonOps again
+```bash
+docker compose up -d
+```
+
+### Stop and delete all data (fresh start)
+```bash
+docker compose down -v
+```
+
+> **Warning:** The `-v` flag removes all stored data. Only use this if you want to start fresh.
+
+---
+
+## Configuration
+
+### Memory Settings
+
+By default, the services use conservative memory settings suitable for development:
+- OpenSearch: 2 GB heap
+- Cassandra: 1 GB heap
+
+For production or larger workloads, increase the memory by setting environment variables before starting:
+
+```bash
+# Set custom memory (before running docker compose up)
+export OPENSEARCH_HEAP_SIZE=4g
+export CASSANDRA_HEAP_SIZE=4096M
+
+# Then start services
+docker compose up -d
+```
+
+Or set them inline:
+```bash
+OPENSEARCH_HEAP_SIZE=4g CASSANDRA_HEAP_SIZE=4096M docker compose up -d
+```
+
+### Authentication
+
+The services use default credentials. For production deployments, change these by setting environment variables:
+
+```bash
+export AXONOPS_SEARCH_USER=admin
+export AXONOPS_SEARCH_PASSWORD=your-secure-password
+export AXONOPS_DB_USERNAME=your-secure-password
+```
+
+### License Key (Optional)
+
+AxonOps is free to use. Enterprise customers with a license key can add it to `axon-server.yml`:
+
+```yaml
+license_key: "your-license-key"
+org: "your-organization-name"
+```
+
+---
+
+## Architecture
+
+This setup runs four services:
+
+| Service | Description | Port |
+|---------|-------------|------|
+| **axon-server** | Backend API server - handles agent connections and data processing | 1888 (agents), 8080 (API) |
+| **axon-dash** | Web dashboard for monitoring and configuration | 3000 |
+| **axondb-search** | OpenSearch database for indexing and search | 9200 (internal) |
+| **timseriesdb** | Cassandra database for time-series data storage | 9042 |
+
+### Data Storage
+
+Your data is stored in Docker volumes, which persist across restarts:
+
+| Volume | Purpose |
+|--------|---------|
+| `searchdb_data` | OpenSearch indices and data |
+| `timeseriesdb_data` | Cassandra time-series data |
+| `axonops_logs` | Application logs |
+
+To see your volumes:
+```bash
+docker volume ls
+```
+
+---
+
+## Troubleshooting
+
+### Services won't start or keep restarting
+
+1. **Check available memory:**
+   ```bash
+   docker stats --no-stream
+   ```
+   If memory is maxed out, increase Docker's memory limit in Docker Desktop settings, or reduce heap sizes.
+
+2. **Check logs for errors:**
+   ```bash
+   docker compose logs axondb-search
+   docker compose logs timseriesdb
+   ```
+
+3. **Restart everything fresh:**
+   ```bash
+   docker compose down -v
+   docker compose up -d
+   ```
+
+### "Cannot connect to the Docker daemon"
+
+- **Mac/Windows:** Make sure Docker Desktop is running
+- **Linux:** Start the Docker service: `sudo systemctl start docker`
+
+### "Port already in use"
+
+Another application is using port 3000, 1888, or 9042. Either:
+- Stop the other application
+- Or edit `docker-compose.yml` to use different ports (e.g., change `"3000:3000"` to `"3001:3000"`)
+
+### Services are "unhealthy"
+
+Wait a few minutes - the databases need time to initialize. If they stay unhealthy:
+```bash
+# Check what's wrong
+docker compose logs axondb-search
+docker compose logs timseriesdb
+
+# Try restarting
+docker compose restart
+```
+
+### Dashboard shows "Cannot connect to server"
+
+The axon-server may still be starting. Wait for it to become healthy:
+```bash
+docker compose ps
+```
+
+---
+
+## Using Podman (Alternative to Docker)
+
+If you prefer Podman:
+```bash
+podman compose up -d
+podman compose ps
+podman compose down
+```
+
+---
 
 ## Health Check Script
 
-This repository includes a **health-check script** (`health-check.sh`) designed to monitor and verify the status of services running in a Docker or Podman Compose environment. It ensures that all expected services in the Compose environment are running and healthy. It helps system administrators or developers quickly identify issues with containerized services by logging errors for any missing or unhealthy services.
-
-### How the Script Works
-
-1. **Logging Errors**:
-   - The script uses a `log_error` function to log error messages to the system's syslog with the tag `container-health-check`.
-
-2. **Container Runtime Selection**:
-   - By default, the script assumes the container runtime is `docker`.
-   - If `podman` is passed as an argument, it switches to using Podman.
-   - If an invalid argument is passed, the script exits with an error message.
-
-3. **Runtime Validation**:
-   - The script checks if the selected container runtime (`docker` or `podman`) is installed and available in the system's PATH.
-   - It also verifies that the Compose plugin for the selected runtime is installed.
-
-4. **Service Status Check**:
-   - The script uses `docker compose ps` (or `podman compose ps`) to list all services in the Compose environment.
-   - It compares these services against a predefined list of expected services: `elasticsearch`, `cassandra`, `axon-server`, and `axon-dash`.
-   - If any expected service is not running, it logs an error.
-
-5. **Health Status Check**:
-   - For each running service, the script retrieves its health status using the `inspect` command.
-   - If a service's health status is not `healthy`, or if its health check fails, an error is logged.
-
-6. **Exit Code**:
-   - The script exits with a code of `0` if all services are running and healthy.
-   - If any issues are detected (e.g., missing or unhealthy services), it exits with a non-zero code.
-
-### **Usage**
-
-To run the script:
+The `check_health.sh` script verifies all services are running correctly:
 
 ```bash
-./health-check.sh [runtime]
+./check_health.sh
 ```
 
-- `[runtime]`: Optional argument to specify the container runtime (`docker` or `podman`). Defaults to `docker`.
+If everything is healthy, you'll see no output. If there are problems, you'll see error messages like:
+```
+ERROR: Service timseriesdb is not running
+ERROR: Service axondb-search is not healthy. Current status: starting
+```
 
-#### **Example Output**
+For Podman users:
+```bash
+./check_health.sh podman
+```
 
-- If all services are running and healthy:
-  ```bash
-  # No output; exit code 0
-  ```
+---
 
-- If a service is missing or unhealthy:
-  ```bash
-  ERROR: Service cassandra is not running
-  ERROR: Service elasticsearch is not healthy. Current status: starting
-  ```
+## Useful Commands Reference
 
-The errors are also logged to syslog for further debugging.
+| Task | Command |
+|------|---------|
+| Start services | `docker compose up -d` |
+| Stop services | `docker compose down` |
+| View status | `docker compose ps` |
+| View logs | `docker compose logs -f` |
+| Restart a service | `docker compose restart axon-server` |
+| Delete everything | `docker compose down -v` |
+| Update images | `docker compose pull && docker compose up -d` |
 
-***
+---
 
-This project may contain trademarks or logos for projects, products, or services. Any use of third-party trademarks or logos are subject to those third-party's policies. AxonOps is a registered trademark of AxonOps Limited. Apache, Apache Cassandra, Cassandra, Apache Spark, Spark, Apache TinkerPop, TinkerPop, Apache Kafka and Kafka are either registered trademarks or trademarks of the Apache Software Foundation or its subsidiaries in Canada, the United States and/or other countries. Elasticsearch is a trademark of Elasticsearch B.V., registered in the U.S. and in other countries. Docker is a trademark or registered trademark of Docker, Inc. in the United States and/or other countries.
+## Getting Help
+
+- **Documentation:** https://axonops.com/docs
+- **Issues:** https://github.com/axonops/axonops-server-compose/issues
+- **Support:** https://axonops.com/contact
+
+---
+
+*This project may contain trademarks or logos for projects, products, or services. Any use of third-party trademarks or logos are subject to those third-party's policies. AxonOps is a registered trademark of AxonOps Limited. Apache, Apache Cassandra, Cassandra, Apache Kafka and Kafka are either registered trademarks or trademarks of the Apache Software Foundation. Docker is a trademark of Docker, Inc. OpenSearch is a trademark of Amazon Web Services.*

--- a/axon-server.yml
+++ b/axon-server.yml
@@ -12,6 +12,8 @@ api_host: 0.0.0.0
 # (AXONSERVER_PORT)
 api_port: 8080
 
+cql_hosts:
+  - timseriesdb
 cql_autocreate_tables: true
 cql_batch_size: 100
 # cql_keyspace_replication: '{ "class": "NetworkTopologyStrategy", "axonopsdb_dc1": 1 }'
@@ -28,6 +30,4 @@ cql_retrypolicy_max: 10s
 cql_retrypolicy_min: 2s
 cql_retrypolicy_numretries: 3
 cql_skip_verify: true
-cql_ssl: true
-cql_username: axonops
-cql_password: elPMIbnoy8M43ukLn4/qjuRC4tk
+cql_ssl: false

--- a/axon-server.yml
+++ b/axon-server.yml
@@ -1,21 +1,33 @@
-host: 0.0.0.0 # axon-server endpoint used by the API and the agents
-api_port: 8080 # API port (axon-server <> axon-dash)
-agents_port: 1888 # axon-server <> axon-agents
-elastic_hosts:
-  - http://elasticsearch:9200
-elastic_discover_nodes: false
+# axon-server listening address (used by axon-agents for connections)
+# (env variable: AXONSERVER_HOST)
+host: 0.0.0.0
+# axon-server listening port for agent connections
+agents_port: 1888
 
-#license_key: enter your AxonOps license key to unlock all features
-#org_name: enter the organisation name associated with your license key
+# axon-server listening address
+# (env variable: used by axon-dash for connections)
+api_host: 0.0.0.0
 
-axon_dash_url: http://axon-dash:3000
+# axon-server HTTP API listening port (used by axon-dash)
+# (AXONSERVER_PORT)
+api_port: 8080
 
 cql_autocreate_tables: true
-cql_hosts:
-  - cassandra
-cql_keyspace: axonops
-cql_username: cassandra
-cql_password: cassandra
-cql_ssl: false
-
-metrics_cache_size_mb: 1024
+cql_batch_size: 100
+# cql_keyspace_replication: '{ "class": "NetworkTopologyStrategy", "axonopsdb_dc1": 1 }'
+cql_local_dc: axonopsdb_dc1
+cql_max_searchqueriesparallelism: 100
+cql_metrics_cache_max_items: 500000
+cql_metrics_cache_max_size: 128
+cql_page_size: 100
+cql_proto_version: 4
+cql_reconnectionpolicy_initialinterval: 1s
+cql_reconnectionpolicy_maxinterval: 10s
+cql_reconnectionpolicy_maxretries: 10
+cql_retrypolicy_max: 10s
+cql_retrypolicy_min: 2s
+cql_retrypolicy_numretries: 3
+cql_skip_verify: true
+cql_ssl: true
+cql_username: axonops
+cql_password: elPMIbnoy8M43ukLn4/qjuRC4tk

--- a/check_health.sh
+++ b/check_health.sh
@@ -39,7 +39,7 @@ fi
 services=$("$CONTAINER_RUNTIME" compose ps --services)
 exit_code=0
 
-expected_services="elasticsearch cassandra axon-server axon-dash"
+expected_services="axondb-search timseriesdb axon-server axon-dash"
 for svc in $expected_services; do
     if ! (echo "$services" | grep -q "$svc"); then
         log_error "Service $svc is not running"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,12 @@ services:
       - cluster.name=axondb-search-cluster
       - node.name=opensearch-node1
       - network.host=0.0.0.0
-      - OPENSEARCH_HEAP_SIZE=${OPENSEARCH_HEAP_SIZE:-2g}
+      - OPENSEARCH_HEAP_SIZE=${OPENSEARCH_HEAP_SIZE:-1g}
       - AXONOPS_SEARCH_TLS_ENABLED=false
       - GENERATE_CERTS_ON_STARTUP=false
       - AXONOPS_SEARCH_ENABLE_BACKUPS=false
       - AXONOPS_SEARCH_USER=${AXONOPS_SEARCH_USER:-admin}
-      - AXONOPS_SEARCH_PASSWORD=${AXONOPS_SEARCH_PASSWORD:-6MP6RzBOpSMKIihacHU0wseu+IU}
+      - AXONOPS_SEARCH_PASSWORD=${AXONOPS_SEARCH_PASSWORD:-6MP6RzBOpSMKIihacHU0wseuIU}
     volumes:
       - searchdb_data:/usr/share/opensearch/data
     healthcheck:
@@ -39,8 +39,8 @@ services:
     restart: unless-stopped
     environment:
       - CASSANDRA_HEAP_SIZE=${CASSANDRA_HEAP_SIZE:-1024M}
-      - AXONOPS_DB_USER=${AXONOPS_DB_USER:-admin}
-      - AXONOPS_DB_PASSWORD=${AXONOPS_DB_PASSWORD:-6MP6RzBOpSMKIihacHU0wseu+IU}
+      - AXONOPS_DB_USER=${AXONOPS_DB_USER:-axonops}
+      - AXONOPS_DB_PASSWORD=${AXONOPS_DB_PASSWORD:-6MP6RzBOpSMKIihacHU0wseuIU}
     volumes:
       - timeseriesdb_data:/var/lib/cassandra
     ports:
@@ -68,11 +68,11 @@ services:
         condition: service_healthy
     environment:
       - SEARCH_DB_USERNAME=${AXONOPS_SEARCH_USER:-admin}
-      - SEARCH_DB_PASSWORD=${AXONOPS_SEARCH_PASSWORD:-6MP6RzBOpSMKIihacHU0wseu+IU}
+      - SEARCH_DB_PASSWORD=${AXONOPS_SEARCH_PASSWORD:-6MP6RzBOpSMKIihacHU0wseuIU}
       - SEARCH_DB_HOSTS=http://axondb-search:9200
       - SEARCH_DB_SKIP_VERIFY=true
-      - CQL_USERNAME=${AXONOPS_DB_USER:-admin}
-      - CQL_PASSWORD=${AXONOPS_DB_PASSWORD:-6MP6RzBOpSMKIihacHU0wseu+IU}
+      - CQL_USERNAME=${AXONOPS_DB_USER:-axonops}
+      - CQL_PASSWORD=${AXONOPS_DB_PASSWORD:-6MP6RzBOpSMKIihacHU0wseuIU}
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://127.0.0.1:8080/api/v1/healthz"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
   axon-server:
     image: registry.axonops.com/axonops-public/axonops-docker/axon-server:2.0.25
     restart: unless-stopped
-    command: ["/usr/share/axonops/axon-server", "-v", "1", "-o", "stdout"]
+    command: ["/usr/share/axonops/axon-server", "-o", "stdout"]
     ports:
       - "1888:1888"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,8 @@ services:
     restart: unless-stopped
     environment:
       - CASSANDRA_HEAP_SIZE=${CASSANDRA_HEAP_SIZE:-1024M}
-      - AXONOPS_DB_USER=admin
-      - AXONOPS_DB_USERNAME=${AXONOPS_DB_USERNAME:-6MP6RzBOpSMKIihacHU0wseu+IU}
+      - AXONOPS_DB_USER=${AXONOPS_DB_USER:-admin}
+      - AXONOPS_DB_PASSWORD=${AXONOPS_DB_PASSWORD:-6MP6RzBOpSMKIihacHU0wseu+IU}
     volumes:
       - timeseriesdb_data:/var/lib/cassandra
     ports:
@@ -71,6 +71,8 @@ services:
       - SEARCH_DB_PASSWORD=${AXONOPS_SEARCH_PASSWORD:-6MP6RzBOpSMKIihacHU0wseu+IU}
       - SEARCH_DB_HOSTS=http://axondb-search:9200
       - SEARCH_DB_SKIP_VERIFY=true
+      - CQL_USERNAME=${AXONOPS_DB_USER:-admin}
+      - CQL_PASSWORD=${AXONOPS_DB_PASSWORD:-6MP6RzBOpSMKIihacHU0wseu+IU}
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://127.0.0.1:8080/api/v1/healthz"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.27
+  axondb-search:
+    image: ghcr.io/axonops/axondb-search:3.3.2
     cap_add:
       - IPC_LOCK
     ulimits:
@@ -10,19 +10,26 @@ services:
     restart: unless-stopped
     environment:
       - discovery.type=single-node
-      - "ES_JAVA_OPTS=-Xms${ELASTICSEARCH_HEAP_SIZE:-8}g -Xmx${ELASTICSEARCH_HEAP_SIZE:-8}g"
+      - cluster.name=axondb-search-cluster
+      - node.name=opensearch-node1
+      - network.host=0.0.0.0
+      - OPENSEARCH_HEAP_SIZE=${OPENSEARCH_HEAP_SIZE:-2g}
+      - AXONOPS_SEARCH_TLS_ENABLED=false
+      - GENERATE_CERTS_ON_STARTUP=false
+      - AXONOPS_SEARCH_ENABLE_BACKUPS=false
+      - AXONOPS_SEARCH_USER=${AXONOPS_SEARCH_USER:-admin}
+      - AXONOPS_SEARCH_PASSWORD=${AXONOPS_SEARCH_PASSWORD:-6MP6RzBOpSMKIihacHU0wseu+IU}
     volumes:
-      - elasticsearch_data:/usr/share/elasticsearch/data
-      - elasticsearch_logs:/usr/share/elasticsearch/logs
+      - searchdb_data:/usr/share/opensearch/data
     healthcheck:
-      test: ["CMD-SHELL", "curl -sS http://127.0.0.1:9200/_cluster/health?wait_for_status=yellow\\&timeout=5s || exit 1"]
+      test: ["CMD-SHELL", "/usr/local/bin/healthcheck.sh readiness"]
       interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 30
       start_period: 90s
 
-  cassandra:
-    image: cassandra:4.1
+  timseriesdb:
+    image: ghcr.io/axonops/axondb-timeseries:5.0.6
     cap_add:
       - IPC_LOCK
     ulimits:
@@ -30,49 +37,52 @@ services:
         soft: -1
         hard: -1
     restart: unless-stopped
-    entrypoint: |
-      sh -c "sed -i 's/^batch_size_warn_threshold:.*$/batch_size_warn_threshold: 64KiB/; s/^batch_size_fail_threshold:.*$/batch_size_fail_threshold: 640KiB/' /etc/cassandra/cassandra.yaml && exec /usr/local/bin/docker-entrypoint.sh"
-    volumes:
-      - cassandra_data:/var/lib/cassandra
-      - cassandra_logs:/var/log/cassandra
     environment:
-      - CASSANDRA_CLUSTER_NAME=axonops-cluster
-      - MAX_HEAP_SIZE=${CASSANDRA_HEAP_SIZE:-8}g
-      - HEAP_NEWSIZE=${CASSANDRA_HEAP_NEWSIZE:-800m}
+      - CASSANDRA_HEAP_SIZE=${CASSANDRA_HEAP_SIZE:-1024M}
+      - AXONOPS_DB_USER=admin
+      - AXONOPS_DB_USERNAME=${AXONOPS_DB_USERNAME:-6MP6RzBOpSMKIihacHU0wseu+IU}
+    volumes:
+      - timeseriesdb_data:/var/lib/cassandra
     ports:
       - "9042:9042"
     depends_on:
-      elasticsearch:
+      axondb-search:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "nodetool statusbinary | grep -E '^running$'"]
+      test: ["CMD-SHELL", "/usr/local/bin/healthcheck.sh readiness"]
       interval: 10s
-      timeout: 5s
+      timeout: 30s
       retries: 20
       start_period: 90s
 
   axon-server:
-    image: registry.axonops.com/axonops-public/axonops-docker/axon-server:latest
+    image: registry.axonops.com/axonops-public/axonops-docker/axon-server:2.0.25
     restart: unless-stopped
-    command: ["/usr/share/axonops/axon-server"]
+    command: ["/usr/share/axonops/axon-server", "-v", "1", "-o", "stdout"]
     ports:
       - "1888:1888"
     depends_on:
-      elasticsearch:
+      axondb-search:
         condition: service_healthy
-      cassandra:
+      timseriesdb:
         condition: service_healthy
+    environment:
+      - SEARCH_DB_USERNAME=${AXONOPS_SEARCH_USER:-admin}
+      - SEARCH_DB_PASSWORD=${AXONOPS_SEARCH_PASSWORD:-6MP6RzBOpSMKIihacHU0wseu+IU}
+      - SEARCH_DB_HOSTS=http://axondb-search:9200
+      - SEARCH_DB_SKIP_VERIFY=true
     healthcheck:
-      test: ["CMD", "curl", "-sf", "127.0.0.1:8080"]
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:8080/api/v1/healthz"]
       interval: 10s
       timeout: 5s
-      start_period: 10s
+      start_period: 30s
+      retries: 10
     volumes:
-        - ./axon-server.yml:/etc/axonops/axon-server.yml:ro
-        - axonops_logs:/var/log/axonops
+      - ./axon-server.yml:/etc/axonops/axon-server.yml:ro
+      - axonops_logs:/var/log/axonops
 
   axon-dash:
-    image: registry.axonops.com/axonops-public/axonops-docker/axon-dash:latest
+    image: registry.axonops.com/axonops-public/axonops-docker/axon-dash:2.0.24
     restart: unless-stopped
     ports:
       - "3000:3000"
@@ -80,7 +90,7 @@ services:
       axon-server:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-sf", "127.0.0.1:3000"]
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:3000"]
       interval: 10s
       timeout: 5s
       start_period: 10s
@@ -89,8 +99,6 @@ services:
       - axonops_logs:/var/log/axonops
 
 volumes:
-  elasticsearch_data:
-  elasticsearch_logs:
-  cassandra_data:
-  cassandra_logs:
+  searchdb_data:
+  timeseriesdb_data:
   axonops_logs:

--- a/run.sh
+++ b/run.sh
@@ -2,10 +2,9 @@
 
 set -e
 
-# Default memory configurations (in GB)
-ELASTICSEARCH_HEAP_SIZE=${ELASTICSEARCH_HEAP_SIZE:-8}
-CASSANDRA_HEAP_SIZE=${CASSANDRA_HEAP_SIZE:-8}
-CASSANDRA_HEAP_NEWSIZE=${CASSANDRA_HEAP_NEWSIZE:-800m}
+# Default memory configurations
+OPENSEARCH_HEAP_SIZE=${OPENSEARCH_HEAP_SIZE:-2g}
+CASSANDRA_HEAP_SIZE=${CASSANDRA_HEAP_SIZE:-1024M}
 
 # Color output
 RED='\033[0;31m'
@@ -36,9 +35,8 @@ Run AxonOps Server with Docker Compose
 OPTIONS:
     -h, --help                              Show this help message
     -d, --detach                            Run in detached mode
-    --es-heap SIZE                          Elasticsearch heap size (default: ${ELASTICSEARCH_HEAP_SIZE}g)
-    --cassandra-heap SIZE                   Cassandra heap size (default: ${CASSANDRA_HEAP_SIZE}g)
-    --cassandra-heap-newsize SIZE           Cassandra new generation heap size (default: ${CASSANDRA_HEAP_NEWSIZE})
+    --opensearch-heap SIZE                  OpenSearch heap size (default: ${OPENSEARCH_HEAP_SIZE})
+    --cassandra-heap SIZE                   Cassandra heap size (default: ${CASSANDRA_HEAP_SIZE})
     --down                                  Stop and remove containers
     --clean                                 Stop containers and remove volumes (WARNING: data will be lost)
 
@@ -46,11 +44,11 @@ EXAMPLES:
     # Run with default settings
     $0
 
-    # Run with custom Elasticsearch heap
-    $0 --es-heap 16
+    # Run with custom OpenSearch heap
+    $0 --opensearch-heap 4g
 
     # Run with custom memory for both services
-    $0 --es-heap 16 --cassandra-heap 16
+    $0 --opensearch-heap 4g --cassandra-heap 4096M
 
     # Run in detached mode
     $0 -d
@@ -62,9 +60,8 @@ EXAMPLES:
     $0 --clean
 
 ENVIRONMENT VARIABLES:
-    ELASTICSEARCH_HEAP_SIZE                 Default: 8 (GB)
-    CASSANDRA_HEAP_SIZE                     Default: 8 (GB)
-    CASSANDRA_HEAP_NEWSIZE                  Default: 800m
+    OPENSEARCH_HEAP_SIZE                    Default: 2g
+    CASSANDRA_HEAP_SIZE                     Default: 1024M
 EOF
 }
 
@@ -82,16 +79,12 @@ while [[ $# -gt 0 ]]; do
             DETACHED="-d"
             shift
             ;;
-        --es-heap)
-            ELASTICSEARCH_HEAP_SIZE="$2"
+        --opensearch-heap)
+            OPENSEARCH_HEAP_SIZE="$2"
             shift 2
             ;;
         --cassandra-heap)
             CASSANDRA_HEAP_SIZE="$2"
-            shift 2
-            ;;
-        --cassandra-heap-newsize)
-            CASSANDRA_HEAP_NEWSIZE="$2"
             shift 2
             ;;
         --down)
@@ -113,7 +106,7 @@ done
 # Handle down and clean actions
 if [ "$ACTION" = "down" ]; then
     print_info "Stopping AxonOps Server containers..."
-    docker-compose down
+    docker compose down
     exit 0
 fi
 
@@ -122,7 +115,7 @@ if [ "$ACTION" = "clean" ]; then
     read -p "Are you sure? (yes/no): " -r
     if [[ $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
         print_info "Cleaning up AxonOps Server..."
-        docker-compose down -v
+        docker compose down -v
         print_info "Cleanup complete"
     else
         print_info "Cleanup cancelled"
@@ -144,12 +137,11 @@ fi
 # Display configuration
 print_info "Starting AxonOps Server with the following configuration:"
 echo ""
-echo "  Elasticsearch:"
-echo "    Heap Size:          ${ELASTICSEARCH_HEAP_SIZE}g"
+echo "  OpenSearch:"
+echo "    Heap Size:          ${OPENSEARCH_HEAP_SIZE}"
 echo ""
 echo "  Cassandra:"
-echo "    Heap Size:          ${CASSANDRA_HEAP_SIZE}g"
-echo "    New Gen Heap Size:  ${CASSANDRA_HEAP_NEWSIZE}"
+echo "    Heap Size:          ${CASSANDRA_HEAP_SIZE}"
 echo ""
 
 # Check if Docker is running
@@ -160,18 +152,17 @@ fi
 
 # Start services
 print_info "Starting services..."
-export ELASTICSEARCH_HEAP_SIZE
+export OPENSEARCH_HEAP_SIZE
 export CASSANDRA_HEAP_SIZE
-export CASSANDRA_HEAP_NEWSIZE
-docker-compose up $DETACHED
+docker compose up $DETACHED
 
 if [ -n "$DETACHED" ]; then
     echo ""
     print_info "Services started in detached mode"
     print_info "Access AxonOps Dashboard at: http://localhost:3000"
     print_info "Cassandra port: 9042"
-    print_info "AxonOps Server port: 1888"
+    print_info "AxonOps Server agent port: 1888"
     echo ""
-    print_info "To view logs: docker-compose logs -f"
+    print_info "To view logs: docker compose logs -f"
     print_info "To stop: $0 --down"
 fi


### PR DESCRIPTION
## Summary

- Migrate from Elasticsearch to OpenSearch (ghcr.io/axonops/axondb-search:3.3.2)
- Migrate from Cassandra 4.1 to Cassandra 5.0.6 (ghcr.io/axonops/axondb-timeseries:5.0.6)
- Update axon-server to 2.0.25 and axon-dash to 2.0.24
- Rewrite README with beginner-friendly documentation
- Update helper scripts for new service names and configuration

## Changes

### docker-compose.yml
- New service names: `axondb-search`, `timseriesdb`
- New container images from ghcr.io/axonops
- Updated healthchecks to use built-in healthcheck scripts

### axon-server.yml
- Updated to connect to OpenSearch instead of Elasticsearch
- Added CQL connection settings for new timeseries image

### README.md
- Complete rewrite with beginner-friendly documentation
- Added prerequisites section
- Added troubleshooting guide
- Updated for new service names and configuration

### run.sh
- Changed `--es-heap` to `--opensearch-heap`
- Updated environment variables
- Modernized to use `docker compose` syntax

### check_health.sh
- Updated expected service names

## Test plan

- [ ] Run `docker compose up -d` and verify all services start healthy
- [ ] Access dashboard at http://localhost:3000
- [ ] Verify `./check_health.sh` reports all services healthy
- [ ] Test `./run.sh -d` starts services correctly